### PR TITLE
Fixed a typo that breaks the template

### DIFF
--- a/templates/scout.yml.erb
+++ b/templates/scout.yml.erb
@@ -5,7 +5,7 @@ log_file: <%= @log_file || '' %>
 ruby_path: <%= @ruby_path || '' %>
 environment: <%= @environment || '' %>
 <% if @roles -%>
-roles: <%= roles.join(',') %>
+roles: <%= @roles.join(',') %>
 <% end -%>
 http_proxy: <%= @http_proxy || '' %>
 https_proxy: <%= @https_proxy || '' %>


### PR DESCRIPTION
Today I discovered that passing any role variable to the scoutd module breaks its config template:

```
Error: Could not retrieve catalog from remote server: Error 500 on SERVER: Server Error: Evaluation Error: Error while evaluating a Function Call, Failed to parse template scoutd/scout.yml.erb:
  Filepath: /etc/puppetlabs/code/environments/production/modules/scoutd/templates/scout.yml.erb
  Line: 8
  Detail: undefined local variable or method `roles' for #<Puppet::Parser::TemplateWrapper:0x5c9a25a7>
 (file: /etc/puppetlabs/code/environments/production/modules/scoutd/manifests/init.pp, line: 133, column: 18) on node 1522771731_duy7ha.opsdev.local
```

That error was caused by undefined variable `roles` within template itself. This change fixes the template and is proven to work on my local environment.

Thanks in advance.